### PR TITLE
New authentication requirement - ProvideOwnTokenRequirement

### DIFF
--- a/Dan.Common/Models/ProvideOwnTokenRequirement.cs
+++ b/Dan.Common/Models/ProvideOwnTokenRequirement.cs
@@ -1,0 +1,5 @@
+namespace Dan.Common.Models
+{
+    [DataContract]
+    public class ProvideOwnTokenRequirement : Requirement { }
+}

--- a/Dan.Core/FuncDirectHarvester.cs
+++ b/Dan.Core/FuncDirectHarvester.cs
@@ -86,7 +86,7 @@ namespace Dan.Core
                 ServiceContext = _requestContextService.ServiceContext.Name
             };
 
-            var evidence = await _evidenceHarvesterService.Harvest(evidenceCodeName, accreditation, _evidenceHarvesterService.GetEvidenceHarvesterOptionsFromRequest());
+            var evidence = await _evidenceHarvesterService.Harvest(evidenceCodeName, accreditation, _requestContextService.GetEvidenceHarvesterOptionsFromRequest());
             _logger.DanLog(accreditation, LogAction.AuthorizationGranted);
 
             var response = req.CreateResponse(HttpStatusCode.OK);

--- a/Dan.Core/FuncEvidenceHarvester.cs
+++ b/Dan.Core/FuncEvidenceHarvester.cs
@@ -65,7 +65,7 @@ namespace Dan.Core
                 throw new NonExistentAccreditationException("The supplied accreditation id was not found or authorization for it failed");
             }
             
-            var evidence = await _evidenceHarvesterService.Harvest(evidenceCodeName, accreditation, _evidenceHarvesterService.GetEvidenceHarvesterOptionsFromRequest());
+            var evidence = await _evidenceHarvesterService.Harvest(evidenceCodeName, accreditation, _requestContextService.GetEvidenceHarvesterOptionsFromRequest());
 
             var response = req.CreateResponse(HttpStatusCode.OK);
             if (req.HasQueryParam("envelope") && !req.GetBoolQueryParam("envelope"))

--- a/Dan.Core/Services/EvidenceHarvesterService.cs
+++ b/Dan.Core/Services/EvidenceHarvesterService.cs
@@ -105,16 +105,6 @@ public class EvidenceHarvesterService : IEvidenceHarvesterService
         return evidence;
     }
 
-    public EvidenceHarvesterOptions GetEvidenceHarvesterOptionsFromRequest()
-    {
-        return new EvidenceHarvesterOptions
-        {
-            OverriddenAccessToken = _requestContextService.Request.Headers.Get(RequestHeaderForwardAccessToken),
-            ReuseClientAccessToken = _requestContextService.Request.GetBoolQueryParam(QueryParamReuseToken),
-            FetchSupplierAccessTokenOnBehalfOfOwner = _requestContextService.Request.GetBoolQueryParam(QueryParamTokenOnBehalfOf)
-        };
-    }
-
     private async Task<List<EvidenceValue>> HarvestEvidenceValues(EvidenceCode evidenceCode, Accreditation accreditation, EvidenceHarvesterOptions? evidenceHarvesterOptions = default)
     {
         var url = evidenceCode.GetEvidenceSourceUrl();

--- a/Dan.Core/Services/Interfaces/IEvidenceHarvesterService.cs
+++ b/Dan.Core/Services/Interfaces/IEvidenceHarvesterService.cs
@@ -6,5 +6,4 @@ public interface IEvidenceHarvesterService
 {
     Task<Evidence> Harvest(string evidenceCodeName, Accreditation accreditation, EvidenceHarvesterOptions? evidenceHarvesterOptions = default);
     Task<Evidence> HarvestOpenData(EvidenceCode evidenceCodeName, string identifier = "");
-    EvidenceHarvesterOptions GetEvidenceHarvesterOptionsFromRequest();
 }

--- a/Dan.Core/Services/Interfaces/IRequestContextService.cs
+++ b/Dan.Core/Services/Interfaces/IRequestContextService.cs
@@ -11,4 +11,5 @@ public interface IRequestContextService
     ServiceContext ServiceContext { get; set; }
     HttpRequestData Request { get; set; }
     Task BuildRequestContext(HttpRequestData request);
+    EvidenceHarvesterOptions GetEvidenceHarvesterOptionsFromRequest();
 }

--- a/Dan.Core/Services/RequestContextService.cs
+++ b/Dan.Core/Services/RequestContextService.cs
@@ -17,6 +17,9 @@ class RequestContextService : IRequestContextService
     public HttpRequestData Request { get; set; }
 
     public const string ServicecontextHeader = "X-NADOBE-SERVICECONTEXT";
+    public const string QueryParamTokenOnBehalfOf = "tokenonbehalfof";
+    public const string QueryParamReuseToken = "reusetoken";
+    public const string RequestHeaderForwardAccessToken = "X-Forward-Access-Token";
 
     public RequestContextService(IServiceContextService serviceContextService)
     {
@@ -47,5 +50,15 @@ class RequestContextService : IRequestContextService
             throw new ServiceNotAvailableException("Missing Service Context definition in request.");
 
         return header.First().ToLowerInvariant();
+    }
+
+    public EvidenceHarvesterOptions GetEvidenceHarvesterOptionsFromRequest()
+    {
+        return new EvidenceHarvesterOptions
+        {
+            OverriddenAccessToken = Request.Headers.Get(RequestHeaderForwardAccessToken),
+            ReuseClientAccessToken = Request.GetBoolQueryParam(QueryParamReuseToken),
+            FetchSupplierAccessTokenOnBehalfOfOwner = Request.GetBoolQueryParam(QueryParamTokenOnBehalfOf)
+        };
     }
 }

--- a/Dan.Core/Services/RequirementValidationService.cs
+++ b/Dan.Core/Services/RequirementValidationService.cs
@@ -104,6 +104,7 @@ public class RequirementValidationService : IRequirementValidationService
             PartyTypeRequirement r => await ValidatePartyTypes(r, _authRequest.Subject, _authRequest.Requestor, _owner, evidenceCodeName),
             AccreditationPartyRequirement r => ValidateAccreditationPartyRequirement(r, _authRequest.Subject, _authRequest.Requestor, _owner, evidenceCodeName),
             ReferenceRequirement r => ValidateReferenceRequirement(r, _authRequest, evidenceCodeName),
+            ProvideOwnTokenRequirement r => ValidateProvideOwnTokenRequirement(r, _authRequest, evidenceCodeName),
             _ => false
         };
 
@@ -536,6 +537,21 @@ public class RequirementValidationService : IRequirementValidationService
         else
         {
             AddError(req, $"The provided {referenceType} is invalid; does not match the regular expression '{req.AcceptedFormat}'", evidenceCodeName);
+            return false;
+        }
+    }
+
+    private bool ValidateProvideOwnTokenRequirement(Requirement req, AuthorizationRequest authRequest, string evidenceCodeName)
+    {
+        EvidenceHarvesterOptions evidenceHarvesterOptions = _requestContextService.GetEvidenceHarvesterOptionsFromRequest();
+
+        if (evidenceHarvesterOptions.OverriddenAccessToken != null || evidenceHarvesterOptions.ReuseClientAccessToken == true || evidenceHarvesterOptions.FetchSupplierAccessTokenOnBehalfOfOwner == true)
+        {
+            return true;
+        }
+        else
+        {
+            AddError(req, $"The dataset {evidenceCodeName} requires that the client provides a bearer token or delegates access to Digitaliseringsdirektoratet", evidenceCodeName);
             return false;
         }
     }


### PR DESCRIPTION
Created a new requirement in common.models. This requires the user to either provide a token in the header, mark their token as reusable, or set digdir as the provider.

Moved GetEvidenceHarvesterOptionsFromRequest from the EvidenceHarvesterService to RequestContextService.

Created validation of ProvideOwnTokenRequirement in the RequirementValidationService.